### PR TITLE
Show saas relation

### DIFF
--- a/jhack/tests/test_scenario/test_darkroom/test_harness_integration/test_darkroom_harness.py
+++ b/jhack/tests/test_scenario/test_darkroom/test_harness_integration/test_darkroom_harness.py
@@ -12,7 +12,7 @@ class MyCharm(CharmBase):
 def test_attach():
     h = Harness(MyCharm, meta=yaml.safe_dump(MyCharm.META))
     l = []
-    d = Darkroom().attach(lambda e, s: l.append((e, s)))
+    Darkroom().attach(lambda e, s: l.append((e, s)))
     h.begin()
     h.add_relation("foo", "remote")
 

--- a/jhack/tests/test_scenario/test_darkroom/test_scenario_integration/test_darkroom_scenario.py
+++ b/jhack/tests/test_scenario/test_darkroom/test_scenario_integration/test_darkroom_scenario.py
@@ -12,7 +12,7 @@ def test_attach():
     Darkroom.uninstall()  # ensure any previous run did not pollute Context.__init__
 
     l = []
-    d = Darkroom().attach(lambda e, s: l.append((e, s)))
+    Darkroom().attach(lambda e, s: l.append((e, s)))
     c = Context(MyCharm, meta=MyCharm.META)
     c.run("start", State())
 

--- a/jhack/tests/test_scenario/test_snapshot/test_dict_to_state.py
+++ b/jhack/tests/test_scenario/test_snapshot/test_dict_to_state.py
@@ -1,4 +1,3 @@
-
 import pytest
 from scenario import (
     Container,

--- a/jhack/utils/event_recorder/client.py
+++ b/jhack/utils/event_recorder/client.py
@@ -212,7 +212,7 @@ def purge_db(
 
 
 def _copy_recorder_script(unit: str):
-    if not "/" in unit:
+    if "/" not in unit:
         exit(f"invalid unit name: {unit!r}; should contain `/<unit id>`")
 
     unit_sanitized = unit.replace("/", "-")

--- a/jhack/utils/integrate.py
+++ b/jhack/utils/integrate.py
@@ -3,7 +3,7 @@ import re
 import time
 from collections import defaultdict
 from functools import partial
-from typing import Dict, List, Optional, Tuple, Union, Iterable
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import typer
 from rich.align import Align


### PR DESCRIPTION
A couple of robustness improvements for jhack show-relation <cmr>

before: you had to be in the consuming model and type a specific sequence of ritualistic symbols for it to work

now: 
- you can be either in the consuming or the providing model
- you can type any order of requirer and provider app

