### PR TITLE
Crpc event env

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,8 +821,26 @@ In a nutshell, `state-apply` _can_ only do:
   - [ ] integrate with Theatre to see the graph expand in real time
 
 
-# CRPC
-`jhack crpc` is a script that allows you to upload a python script to one or multiple live Juju 
+# crpc
+`jhack crpc` is a command that allows you to evaluate simple one-line expressions in the context of a live charm (or multiple units thereof).
+
+> `jhack crpc myapp/0 self.model.relations`
+
+and you should see as output the current list of relations the charm has, for example
+
+> `[<ops.model.Relation ingress:50>]`
+
+Similarly, if the charm has a method called `_foobar`, you could write:
+
+> `jhack crpc myapp/0 self._foobar() + 42`
+
+and see the result in your standard output.
+
+Run the command with `--help` for additional options and configuration.
+
+
+# script
+`jhack script` is a command that allows you to upload a python script to one or multiple live Juju 
 units and running them with the charm instance as an argument.
 
 ```python
@@ -836,7 +854,9 @@ def main(charm):
 
 Now type:
 
-> `jhack crpc myapp/0 --input ./path/to/script.py`
+> `jhack script myapp/0 --input ./path/to/script.py`
 
 and you should see as output the current value of the `key` application data setting. 
 You will also see that the `other-key` has been updated to `"value"`.
+
+Run the command with `--help` for additional options and configuration.

--- a/jhack/helpers.py
+++ b/jhack/helpers.py
@@ -262,7 +262,6 @@ def _push_file_k8s_cmd(
     container: Optional[str] = None,
     model: str = None,
 ):
-
     container_arg = f" --container {container} " if container else ""
     model_arg = f" -m {model}" if model else ""
 

--- a/jhack/main.py
+++ b/jhack/main.py
@@ -39,6 +39,7 @@ def main():
     from jhack.scenario.snapshot import snapshot
     from jhack.scenario.state_apply import state_apply
     from jhack.utils import integrate
+    from jhack.utils.charm_rpc import charm_rpc
     from jhack.utils.event_recorder.client import (
         dump_db,
         emit,
@@ -51,7 +52,6 @@ def main():
     from jhack.utils.nuke import nuke
     from jhack.utils.print_env import print_env
     from jhack.utils.show_relation import sync_show_relation
-    from jhack.utils.charm_rpc import charm_rpc
     from jhack.utils.show_stored import show_stored
     from jhack.utils.simulate_event import simulate_event
     from jhack.utils.sync import sync as sync_deployed_charm

--- a/jhack/main.py
+++ b/jhack/main.py
@@ -39,7 +39,7 @@ def main():
     from jhack.scenario.snapshot import snapshot
     from jhack.scenario.state_apply import state_apply
     from jhack.utils import integrate
-    from jhack.utils.charm_rpc import charm_rpc
+    from jhack.utils.charm_rpc import charm_rpc, charm_script
     from jhack.utils.event_recorder.client import (
         dump_db,
         emit,
@@ -72,6 +72,7 @@ def main():
     utils.command(name="pull-cmr", no_args_is_help=True)(integrate.cmr)
     utils.command(name="print-env")(print_env)
     utils.command(name="crpc", no_args_is_help=True)(charm_rpc)
+    utils.command(name="script", no_args_is_help=True)(charm_script)
 
     jinx = typer.Typer(
         name="jinx",
@@ -126,6 +127,7 @@ def main():
     app.command(name="jenv")(print_env)
     app.command(name="list-endpoints")(list_endpoints)
     app.command(name="crpc", no_args_is_help=True)(charm_rpc)
+    app.command(name="script", no_args_is_help=True)(charm_script)
 
     conf = typer.Typer(
         name="conf",

--- a/jhack/utils/.charm_rpc_dispatch.py
+++ b/jhack/utils/.charm_rpc_dispatch.py
@@ -1,3 +1,4 @@
+import base64
 import importlib
 import inspect
 import logging
@@ -27,34 +28,49 @@ def _deserialize_env(s: str) -> Dict[str, str]:
 ENV: Dict[str, str] = _deserialize_env(os.getenv("CHARM_RPC_ENV"))
 MODULE_NAME = os.getenv("CHARM_RPC_MODULE_NAME")  # string
 ENTRYPOINT = os.getenv("CHARM_RPC_ENTRYPOINT")  # string
-SCRIPT_NAME = os.getenv("CHARM_RPC_SCRIPT_NAME")  # string
 LOGLEVEL = os.getenv("CHARM_RPC_LOGLEVEL")  # string
+EVAL_EXPR = os.getenv("CHARM_RPC_EXPR")  # string
 
 logger = logging.getLogger("charm-rpc")
 logger.setLevel(LOGLEVEL)
 
 
+def _decode(expr: str) -> str:
+    return base64.b64decode(expr.encode("utf-8")).decode("ascii")
+
+
 def rpc(charm):
-    # load module
-    module = importlib.import_module(MODULE_NAME)
-    entrypoint = getattr(module, ENTRYPOINT)
-    logger.debug(
-        f"found entrypoint {ENTRYPOINT!r} in {SCRIPT_NAME}. Invoking on charm..."
-    )
-    return_value = entrypoint(charm)
-    return return_value
+    if MODULE_NAME:
+        logger.debug("running rpc in script mode")
+
+        # load module
+        module = importlib.import_module(MODULE_NAME)
+        entrypoint = getattr(module, ENTRYPOINT)
+        logger.debug(
+            f"found entrypoint {ENTRYPOINT!r} in crpc script. Invoking on charm..."
+        )
+        return_value = entrypoint(charm)
+        return return_value
+
+    elif EVAL_EXPR:
+        expr = _decode(EVAL_EXPR)
+        logger.debug(f"running rpc in eval-expr mode: \n" f"expr={expr!r}")
+        try:
+            return eval(expr, {"self": charm})
+        except Exception:  # noqa
+            logger.exception(f"failed executing {expr} in with self={charm}.")
 
 
 def ops_main_rpc(charm_class: Type[ops.charm.CharmBase], use_juju_for_storage: bool):
+    # inject the juju envvars we need
+    os.environ.update(ENV)
+
     charm_dir = _get_charm_dir()
 
     model_backend = ops.model._ModelBackend()
     debug = "JUJU_DEBUG" in os.environ
     setup_root_logging(model_backend, debug=debug)
     logger.debug("charm rpc dispatch v0.1 up and running.")
-
-    # inject the juju envvars we need
-    os.environ.update(ENV)
 
     dispatcher = _Dispatcher(charm_dir)
     metadata = (charm_dir / "metadata.yaml").read_text()

--- a/jhack/utils/show_relation.py
+++ b/jhack/utils/show_relation.py
@@ -7,7 +7,7 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
-from typing import Dict, List, Optional, Tuple, Any
+from typing import Any, Dict, List, Optional, Tuple
 
 import typer
 

--- a/jhack/utils/simulate_event.py
+++ b/jhack/utils/simulate_event.py
@@ -62,13 +62,14 @@ def _get_relation_endpoint(event: str):
     return False
 
 
-def _get_env(
+def build_event_env(
     unit,
     event,
     relation_remote: str = None,
     override: List[str] = None,
     operator_dispatch: bool = False,
     model: str = None,
+    glue: str = " ",
 ):
     current_model = get_current_model()
     env = {
@@ -130,7 +131,7 @@ def _get_env(
         logger.debug(f"removed {juju_context_id}")
         del env[juju_context_id]
 
-    return " ".join(f"{k}={v}" for k, v in env.items())
+    return glue.join(f"{k}={v}" for k, v in env.items())
 
 
 def _simulate_event(
@@ -150,7 +151,7 @@ def _simulate_event(
             f"invalid unit name: should be something like 'foo/0', not {unit}"
         )
 
-    env = _get_env(
+    env = build_event_env(
         unit,
         event,
         relation_remote=relation_remote,

--- a/jhack/utils/sync.py
+++ b/jhack/utils/sync.py
@@ -9,7 +9,7 @@ from typing import List
 
 import typer
 
-from jhack.helpers import JPopen, get_substrate, juju_status, push_file
+from jhack.helpers import juju_status, push_file
 from jhack.logger import logger
 
 logger = logger.getChild(__file__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jhack"
-version = "0.3.33"
+version = "0.3.34"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jhack"
-version = "0.3.34"
+version = "0.4"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
 ]


### PR DESCRIPTION
- renames `crpc` to `script`
- adds `crpc` as a way to run simple expressions on the charm. `jhack crpc unit/0 self._do_this_thing()` or `jhack crpc unit/0 self.model.relations[0].app.name`

Fixes #135 

allows `jhack crpc myapp/0 --input some/file.py --event foo-relation-changed --env FOO=BAR`

useful if charms use event-specific (or entirely custom?) context vars to do their logic.