### PR TITLE
lobo path to return custom code

### DIFF
--- a/jhack/charm/dispatch_lobo.sh
+++ b/jhack/charm/dispatch_lobo.sh
@@ -7,11 +7,14 @@ DISABLED={%DISABLED%}
 if [ "$DISABLED" = "ALL" ]
 then
   juju-log full lobotomy ACTIVE: event "${JUJU_DISPATCH_PATH}" ignored.
-  exit 0
+  exit {%EXIT_CODE%}
 fi
 
 case ",$JUJU_DISPATCH_PATH," in
   (*,"$DISABLED",*)
-   juju-log selective lobotomy ACTIVE: event "${JUJU_DISPATCH_PATH}" ignored.;;
-  (*) exec ./dispatch.ori;;
+   juju-log selective lobotomy ACTIVE: event "${JUJU_DISPATCH_PATH}" ignored.
+   exit {%EXIT_CODE%}
+   ;;
+  (*) exec ./dispatch.ori
+  ;;
 esac


### PR DESCRIPTION
Adds a --retry flag so that `jhack charm lobotomy` can have the dispatch path exit nonzero. 
This is useful if you want juju to be aware that the charm isn't processing events.
Usage:
 - jhack lobotomy foo/0
 - (do things), charm goes to error state
 - jhack lobotomy foo/0 --undo
 - juju resolve foo/0 
 - charm receives all queued events