### PR TITLE
docs: update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,13 @@ More extensive documentation is provided in the cli itself. All commands can be 
 Clone the repo
 
 ```shell
-pip install -r requirements.txt
 pip install -e .
 ```
 
 ##### as package (requires setuptools 61 or later):
 
 ```shell
-pip install git+https://github.com/PietroPasotti/jhack
+pip install git+https://github.com/canonical/jhack
 ```
 
 ##### as snap:


### PR DESCRIPTION
1. No need to install the requirements explicitly, pip + pyproject.toml's dependency list will do that
2. I assume the instructions should point to the canonical Canonical repo rather than the Pietro one when installing from git