### PR TITLE
chore(configure): Remove duplicate call

### DIFF
--- a/jhack/__init__.py
+++ b/jhack/__init__.py
@@ -1,8 +1,6 @@
 #!/bin/python3
 
 if __name__ == "__main__":
-    from jhack.config import configure
     from jhack.main import main
 
-    configure()
     main()


### PR DESCRIPTION
`configure()` is called in `__init__.py` before `main()`, however `main()` calls `configure()` before doing anything else.

I'm removing the call in `__init__.py`, since the history shows that the second call in `main.py` was added after that and I believe the intent was that it is called there (and it was not cleaned up).