### PR TITLE
feat: add support for Pebble check-failed and check-recovered events

### DIFF
--- a/jhack/helpers.py
+++ b/jhack/helpers.py
@@ -574,6 +574,15 @@ def get_notices(unit: str, container_name: str, model: str = None):
     return json.loads(JPopen(shlex.split(cmd), text=True).stdout.read())["result"]
 
 
+def get_checks(unit: str, container_name: str, model: str = None):
+    _model = f"{model} " if model else ""
+    cmd = (
+        f"juju ssh {_model}{unit} curl --unix-socket /charm/containers/{container_name}"
+        f"/pebble.socket http://localhost/v1/checks"
+    )
+    return json.loads(JPopen(shlex.split(cmd), text=True).stdout.read())["result"]
+
+
 def get_secrets(model: str = None) -> dict:
     _model = f"{model} " if model else ""
     cmd = f"juju secrets {_model} --format=json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jhack"
-version = "0.4.2.3"
+version = "0.4.3.0"
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }
 ]


### PR DESCRIPTION
Adds explicit support to `jhack fire` for `<container-name>-pebble-check-failed` and `<container-name>-pebble-check-recovered` events.

In very much the same way as notice events prompt asking for the appropriate notice, this will prompt for the appropriate check, if necessary.

[OP045](https://docs.google.com/document/d/1EgRwMarsAOB04zWdSpcHbP0VykRApxQlyNFF1oC2Gzw/edit)