### PR TITLE
Update description for --source option of jhack sync

### DIFF
--- a/jhack/utils/sync.py
+++ b/jhack/utils/sync.py
@@ -270,7 +270,7 @@ def sync(
         "--source",
         "-s",
         help="Local directories to watch for changes. "
-        "Semicolon-separated list of directories.",
+        "Repeat for each directory (e.g --source ./src --source .lib).",
     ),
     remote_root: str = typer.Option(
         None,

--- a/jhack/utils/sync.py
+++ b/jhack/utils/sync.py
@@ -270,7 +270,7 @@ def sync(
         "--source",
         "-s",
         help="Local directories to watch for changes. "
-        "Repeat for each directory (e.g --source ./src --source .lib).",
+        "Repeat for each directory (e.g --source ./src --source ./lib).",
     ),
     remote_root: str = typer.Option(
         None,


### PR DESCRIPTION
I found that the `--source` option doesn't actually take a semicolon-separated list like the description suggests (I was trying it like this `--source=./lib;./src;./templates`). But it actually repeated for each value in the list like in the typer docs : https://typer.tiangolo.com/tutorial/multiple-values/multiple-options/.

So I made a trivial change to update the description and provide and example.