### PR TITLE
Fix for #210 (`jhack nuke -m test` not removing the model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,21 +593,6 @@ Future work:
   have it talk to a real backend living somewhere else.
 
 
-# model
-## clear
-
-`jhack model clear`
-
-Will nuke all applications in the current model.
-
-
-## rm
-
-`jhack model rm`
-
-Will nuke the current model.
-
-
 # charm
 
 ## update

--- a/jhack/tests/utils/test_nuke.py
+++ b/jhack/tests/utils/test_nuke.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from jhack.utils.nuke import Nukeable, app
+
+
+class TestModelNuking(unittest.TestCase):
+
+    @patch("jhack.utils.nuke.fire")
+    def test_nuke_model(self, mock_fire):
+        test_model = "testing"
+
+        runner = CliRunner()
+        _ = runner.invoke(app, ["--model", test_model])
+
+        expected_nukeable = Nukeable(name=test_model, type="model")
+
+        mock_fire.assert_called_once_with(
+            expected_nukeable,
+            f"juju destroy-model --force --no-wait --destroy-storage --no-prompt {test_model}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/jhack/tests/utils/test_nuke.py
+++ b/jhack/tests/utils/test_nuke.py
@@ -1,27 +1,22 @@
-import unittest
 from unittest.mock import patch
 
+from typer import Typer
 from typer.testing import CliRunner
 
-from jhack.utils.nuke import Nukeable, app
+from jhack.utils.nuke import Nukeable, nuke
 
 
-class TestModelNuking(unittest.TestCase):
+def test_nuke_model():
+    test_model = "testing"
 
-    @patch("jhack.utils.nuke.fire")
-    def test_nuke_model(self, mock_fire):
-        test_model = "testing"
-
-        runner = CliRunner()
+    runner = CliRunner()
+    app = Typer()
+    app.command()(nuke)
+    with patch("jhack.utils.nuke.fire") as mock_fire:
         _ = runner.invoke(app, ["--model", test_model])
 
         expected_nukeable = Nukeable(name=test_model, type="model")
-
         mock_fire.assert_called_once_with(
             expected_nukeable,
             f"juju destroy-model --force --no-wait --destroy-storage --no-prompt {test_model}",
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/jhack/tests/utils/test_nuke.py
+++ b/jhack/tests/utils/test_nuke.py
@@ -12,7 +12,7 @@ def test_nuke_model():
     runner = CliRunner()
     app = Typer()
     app.command()(nuke)
-    with patch("jhack.utils.nuke.fire") as mock_fire:
+    with patch("jhack.utils.nuke._fire") as mock_fire:
         _ = runner.invoke(app, ["--model", test_model])
 
         expected_nukeable = Nukeable(name=test_model, type="model")

--- a/jhack/utils/nuke.py
+++ b/jhack/utils/nuke.py
@@ -546,7 +546,7 @@ def nuke(
         color=color,
         gently=gently,
     )
-    if what == []:
+    if what is None:
         _nuke(None, **kwargs)
     else:
         for obj in what:

--- a/jhack/utils/nuke.py
+++ b/jhack/utils/nuke.py
@@ -301,7 +301,6 @@ def _nuke(
     gently: bool = GENTLY,
 ):
 
-    # breakpoint()
     cur_model = model or get_current_model()
     if not cur_model:
         nukeables = []
@@ -341,6 +340,7 @@ def _nuke(
             cur_model=cur_model,
         )
         logger.debug(f"Gathered: {nukeables}")
+
     politeness = " --force --no-wait" if not gently else ""
     nukes = []
     nuked_apps = set()
@@ -550,7 +550,7 @@ def nuke(
         color=color,
         gently=gently,
     )
-    if what == []:
+    if what is None:
         _nuke(None, **kwargs)
     else:
         for obj in what:

--- a/jhack/utils/nuke.py
+++ b/jhack/utils/nuke.py
@@ -460,10 +460,6 @@ def _nuke(
         print_centered(Text("✞ RIP ✞", style=Style(bold=True, dim=True)), color=color)
 
 
-app = typer.Typer()
-
-
-@app.command()
 def nuke(
     what: List[str] = typer.Argument(None, help=f"What to {ATOM}."),
     selectors: str = typer.Option(
@@ -550,7 +546,7 @@ def nuke(
         color=color,
         gently=gently,
     )
-    if what is None:
+    if what == []:
         _nuke(None, **kwargs)
     else:
         for obj in what:

--- a/jhack/utils/nuke.py
+++ b/jhack/utils/nuke.py
@@ -254,12 +254,12 @@ def _gather_nukeables(
     return nukeables
 
 
-def print_centered(s, color: _Color = "auto"):
+def _print_centered(s, color: _Color = "auto"):
     console = Console(color_system=color)
     return console.print(Align(s, align="center"))
 
 
-def fire(nukeable: Nukeable, nuke: str):
+def _fire(nukeable: Nukeable, nuke: str):
     """defcon 5"""
     _atom = Style(bold=True, color="green")
 
@@ -272,7 +272,7 @@ def fire(nukeable: Nukeable, nuke: str):
         Text(ICBM + " " * 2).append(nukeable_name, to_nuke).append("  " + ATOM, _atom)
     )
 
-    print_centered(text)
+    _print_centered(text)
 
     # todo split model nukes to a separate process and pass there shell=True
     logger.debug(f"nuking {nukeable} with {nuke}")
@@ -427,7 +427,7 @@ def _nuke(
         color = None
         
     ascii_art = NUKE_GENTLY_ASCII_ART if gently else NUKE_ASCII_ART
-    print_centered(
+    _print_centered(
         Text(
             ascii_art,
             style=Style(dim=True, blink=BLINK, bold=True),
@@ -439,7 +439,7 @@ def _nuke(
     results = []
     for nukeable, nuke in zip(nukeables, nukes):
         logger.debug(f"firing {nuke} {ICBM} {nukeable}")
-        res = tp.apply_async(fire, (nukeable, nuke))
+        res = tp.apply_async(_fire, (nukeable, nuke))
         results.append((res, nukeable, nuke))
 
     with timeout(1):
@@ -448,16 +448,16 @@ def _nuke(
 
     for res, nkbl, nk in results:
         if not res.ready():
-            print_centered(f"{ICBM} {nkbl} still in flight", color=color)
+            _print_centered(f"{ICBM} {nkbl} still in flight", color=color)
         else:
             if not res.successful():
-                print_centered(
+                _print_centered(
                     f"nuke {nk!r} {ICBM} {nkbl!r} failed; someone doesn't want to die",
                     color=color,
                 )
 
     if not dry_run:
-        print_centered(Text("✞ RIP ✞", style=Style(bold=True, dim=True)), color=color)
+        _print_centered(Text("✞ RIP ✞", style=Style(bold=True, dim=True)), color=color)
 
 
 def nuke(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["juju", "hacks", "cli", "charm", "charming"]
 urls.Source = "https://github.com/canonical/jhack"
 dependencies = [
     "ops[testing](==2.17.1)",
-    "typer(==0.7.0)",
+    "typer(==0.15.2)",
     "black",
     "rich(==13.3.0)",
     "parse(==1.19.0)",


### PR DESCRIPTION
## Overview

This PR fixes the issue #210 . This bug would also affect other cases where `what` argument isn't provided and only options are passed. For example - `jhack nuke -s ar`

## The problem

1. The typer argument `what` is compared with `None` in line [535](https://github.com/canonical/jhack/blob/81b1ea1acd0c9857d78a081f26cec3498be27354/jhack/utils/nuke.py#L535).
2. `what` is expected to return `None` when it is not set since that is the default value set in line [450](https://github.com/canonical/jhack/blob/81b1ea1acd0c9857d78a081f26cec3498be27354/jhack/utils/nuke.py#L450)
3. When `what` isn't provided, typer returns an empty list [] instead of `None`

## The root cause

I believe this is because of the way Typer treats variadic arguments (i.e., arguments that accept multiple values, like List[str]) differently. When the type List[str] is provided for `what`, typer returns [] instead of `None`. Changing the type to `Optional[List[str]]` doesn't make a difference to what typer returns. ([Reference](https://typer.tiangolo.com/tutorial/arguments/default/#an-optional-cli-argument-with-a-default:~:text=Have%20in%20mind%20that%20the%20Optional%5Bsomething%5D%20tells%20Python%20that%20a%20value%20%22could%20be%20None%22.%20But%20the%20use%20of%20Optional%20doesn%27t%20affect%20Typer%20in%20any%20way%2C%20e.g.%20it%20doesn%27t%20tell%20Typer%20if%20a%20value%20is%20required%20or%20not.)) This seems to be an issue with the typer library.

## The Fix

- Upgrade typer to the latest version `0.15.2`

## Changes Made

1. Added a test case that would fail if the `what` argument is validated against `None`.
2. Moved the `fire` and `print_centered` functions outside the `_nuke` function to make it easier to mock them while testing.
3. Updated the `README.md` to remove any reference to `jhack model` commands since I don't see the command itself.