### PR TITLE
docs: correctly describe behaviour when container isn't specified

### DIFF
--- a/jhack/utils/pebble.py
+++ b/jhack/utils/pebble.py
@@ -64,7 +64,7 @@ def pebble(
         "-c",
         "--container",
         help="Container name to target. "
-        "Will default to the first container defined in charmcraft.yaml if none is provided.",
+        "Will execute for each container in turn if none is specified.",
     ),
     model: Optional[str] = typer.Option(
         None,


### PR DESCRIPTION
Just a small PR updating the CLI documentation for the new `pebble` command's behaviour when no container is specified, to match the current runtime behaviour.