### PR TITLE
feat: Reliable home dir getter

### DIFF
--- a/jhack/config.py
+++ b/jhack/config.py
@@ -1,7 +1,7 @@
 """Jhack configuration module."""
 
 import os
-import pwd
+import getpass
 import sys
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
@@ -14,25 +14,12 @@ JHACK_PROJECT_ROOT = Path(__file__).parent.parent
 
 def get_home_dir() -> Path:
     """Get the path to the home directory for the user."""
-    try:
-        usr = pwd.getpwuid(os.getuid())[0]
-    except KeyError:
-        logger.debug(
-            "pwd.getpwuid could not get pwd for your UID. "
-            "If you think you're root, something must have gone wrong. "
-            "Set the envvar JHACK_DATA to some snap-writable path where "
-            "jhack should store its data and config."
-        )
-        usr = ""
+    # First, we get the user in a reliable way
+    user = getpass.getuser()
 
-    if usr == "root":
-        home_dir = Path("/root")
-    elif user := os.environ.get("USER"):
-        home_dir = Path("/home") / user
-    else:
-        # this looks up the ~HOME envvar and tries more things if not set (see pathlib._PosixFlavour.gethomedir)
-        home_dir = Path("~").expanduser().absolute()
-    return home_dir
+    # We then expand the path of the user we found
+    # (otherwise snap will pick $HOME == /home/<user>/snap/jhack/current/)
+    return Path(f"~{user}").expanduser().absolute()
 
 
 def get_jhack_data_path() -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jhack"
-version = "0.4.4.0.18"
+version = "0.4.4.0.19"
 requires-python = ">=3.10" # core24 supports up to 3.12 but data platform depends on 3.10
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }


### PR DESCRIPTION
First we proceed to get the current user from the system We then expand its home path using ~user instead of just ~ so it expands for a specific user.


Fixes #213 