### PR TITLE
Fix crash on startup when config file is unreadable (#244)

### DIFF
--- a/jhack/conf/conf.py
+++ b/jhack/conf/conf.py
@@ -62,12 +62,16 @@ class Config:
     def _load(self):
         try:
             self._data = toml.load(self._path.open())
-        except PermissionError as e:
-            logger.error(
-                f"Unable to open config file at {self._path}."
-                f"Try `sudo snap connect jhack:dot-config-jhack snapd`."
+        except (PermissionError, OSError) as e:
+            logger.warning(
+                f"Unable to open config file at {self._path}: {e}. "
+                f"Falling back to default config. "
+                f"Your config has not been persisted. "
+                f"If you want to unblock this, check the permissions on {self._path}. "
+                f"Snap users: try `sudo snap connect jhack:dot-config-jhack snapd`."
             )
-            raise e
+            self._data = toml.load(self._DEFAULTS.open())
+            self.is_default = True
 
     @property
     def data(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jhack"
-version = "0.4.4.0.26"
+version = "0.4.4.0.27"
 requires-python = ">=3.10" # core24 supports up to 3.12 but data platform depends on 3.10
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }


### PR DESCRIPTION
## Summary
- When the config file exists but can't be read (e.g. permissions), jhack now falls back to the default config instead of crashing with a `PermissionError`.
- A warning is logged telling the user their config hasn't been persisted and how to fix the permissions.

Closes #244