### PR TITLE
fix: fix jhack tail to work in no tty

### DIFF
--- a/jhack/utils/tail_charms/tail_charms.py
+++ b/jhack/utils/tail_charms/tail_charms.py
@@ -1,4 +1,6 @@
+import os
 import re
+import stat as _stat
 import sys
 from pathlib import Path
 from typing import (
@@ -183,9 +185,11 @@ def _tail_charms(
             False  # it's too late for that, we're replaying the history and transforming it.
         )
 
-    # FIXME: when debugging, this heuristic is incorrect.
-    read_from_stdin = not sys.stdin.isatty()
-    # read_from_stdin = False
+    # Only treat stdin as an input source when it is an actual pipe or file.
+    # A bare non-TTY context (e.g. GitHub Actions, /dev/null redirect) is a
+    # character device, not a FIFO, so it should not be mistaken for piped input.
+    _stdin_mode = os.fstat(sys.stdin.fileno()).st_mode
+    read_from_stdin = _stat.S_ISFIFO(_stdin_mode) or _stat.S_ISREG(_stdin_mode)
 
     if (read_from_stdin or files) and auto_bump_loglevel:
         logger.debug("static input mode. Overriding auto loglevel bumping.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jhack"
-version = "0.4.4.0.27"
+version = "0.4.4.0.28"
 requires-python = ">=3.10" # core24 supports up to 3.12 but data platform depends on 3.10
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }


### PR DESCRIPTION
Fixes the problems we've been facing on our CIs where jhack does not catch any events.
See [valkey](https://github.com/canonical/valkey-operator/actions/runs/26990016886/job/79675446713#step:12:6), [OS](https://github.com/canonical/opensearch-single-kernel-library/actions/runs/26990058796/job/79651083964#step:15:64)
This pull request updates the logic for detecting piped input in the `jhack.utils.tail_charms` utility and bumps the package version. The most significant change ensures that stdin is only treated as input when it is a pipe or file, preventing incorrect behavior in certain environments.

Input detection improvements:

* Updated `_tail_charms` to check if stdin is a FIFO or regular file using `os.fstat` and `stat`, instead of relying solely on `sys.stdin.isatty()`. This prevents misidentifying character devices (like `/dev/null` or CI environments) as piped input.
* Added imports for `os` and `stat` in `tail_charms.py` to support the new input detection logic.

Versioning:

* Bumped the package version in `pyproject.toml` from `0.4.4.0.27` to `0.4.4.0.28`.