### PR TITLE
feat: --devmode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,24 @@ These commands will prompt the user for confirmation before proceeding, after, w
 ## Enabling devmode
 In devmode, destructive commands will be run without requiring a confirmation prompt.
 
-You can permanently enable devmode by setting `~/.config/jhack/config.toml` (see `jhack conf`) and set `[general]enable_destructive_commands_NO_PRODUCTION_zero_guarantees` to `true`.
+There are three ways to bypass the safety confirmation prompt:
 
-To view example 'destructive' and 'yolo' profiles, you can run: 
+1. **Permanent** — set `~/.config/jhack/config.toml` (see `jhack conf`) and set
+   `[general]enable_destructive_commands_NO_PRODUCTION_zero_guarantees` to `true`.
 
-> `jhack conf destructive` 
-> `jhack conf yolo` 
+   To view example 'destructive' and 'yolo' profiles, you can run:
+   > `jhack conf destructive`
+   > `jhack conf yolo`
 
-Otherwise, set the `JHACK_PROFILE=devmode` envvar to run a single command without the confirmation prompt. 
+2. Per-session (environment): export this envvar to bypass safety safeguards for a session:
+   > `export JHACK_PROFILE=devmode`
+3. Per-command (environment): set the `JHACK_PROFILE=devmode` envvar for a single invocation:
+   > `JHACK_PROFILE=devmode jhack fire prom/0 update-status`
+   
+4. Per-command (CLI flag): pass the `--devmode` flag anywhere in the command:
+   > `jhack fire prom/0 update-status --devmode`
+   > `jhack --devmode sync`
+   > `jhack nuke --devmode`
 
 As only exception, nuke has a double safeguard in that even if you enable devmode, you will still get a confirmation prompt.
 To disable that one, set `[nuke]ask_for_confirmation` to `false`.

--- a/jhack/conf/conf.py
+++ b/jhack/conf/conf.py
@@ -176,20 +176,20 @@ def doc_devmode_only(command: types.FunctionType):
     return command
 
 
-_YES_FLAG = False
+_DEVMODE_FLAG = False
 
 
-def enable_yes_flag():
-    global _YES_FLAG
-    _YES_FLAG = True
+def enable_devmode_flag():
+    global _DEVMODE_FLAG
+    _DEVMODE_FLAG = True
 
 
 def check_destructive_commands_allowed(
     msg: str, dry_run_cmd: str = "", _check_only=False
 ) -> Union[_Denied, _Allowed]:
-    if _YES_FLAG:
-        logger.debug(f"operation {msg!r} allowed by --yes flag.")
-        return _Allowed(_Reason.user)
+    if _DEVMODE_FLAG:
+        logger.debug(f"operation {msg!r} allowed by --devmode flag.")
+        return _Allowed(_Reason.devmode_temp)
 
     if os.getenv("JHACK_PROFILE") == "devmode":
         logger.debug(f"operation {msg!r} allowed by devmode profile.")

--- a/jhack/conf/conf.py
+++ b/jhack/conf/conf.py
@@ -176,9 +176,21 @@ def doc_devmode_only(command: types.FunctionType):
     return command
 
 
+_YES_FLAG = False
+
+
+def enable_yes_flag():
+    global _YES_FLAG
+    _YES_FLAG = True
+
+
 def check_destructive_commands_allowed(
     msg: str, dry_run_cmd: str = "", _check_only=False
 ) -> Union[_Denied, _Allowed]:
+    if _YES_FLAG:
+        logger.debug(f"operation {msg!r} allowed by --yes flag.")
+        return _Allowed(_Reason.user)
+
     if os.getenv("JHACK_PROFILE") == "devmode":
         logger.debug(f"operation {msg!r} allowed by devmode profile.")
         return _Allowed(_Reason.devmode_temp)

--- a/jhack/main.py
+++ b/jhack/main.py
@@ -33,6 +33,7 @@ def main():
     from jhack.charm.update import update
     from jhack.charm.vinfo import vinfo
     from jhack.conf.conf import (
+        enable_yes_flag,
         print_current_config,
         print_defaults,
         print_destructive,
@@ -81,6 +82,16 @@ def main():
         sep = sys.argv.index("--")
         typer.Typer._extra_args = sys.argv[sep + 1 :]
         sys.argv = sys.argv[:sep]
+
+    # Strip -y/--yes from anywhere in argv before Typer parses them,
+    # so the flag works regardless of position in the command.
+    remaining = [sys.argv[0]]
+    for arg in sys.argv[1:]:
+        if arg in ("-y", "--yes"):
+            enable_yes_flag()
+        else:
+            remaining.append(arg)
+    sys.argv = remaining
 
     # Add to all devmode-only commands a doc line warning the user it's only "safe" but not ``safe`` to use them
     for devmode_only_command in {
@@ -263,7 +274,14 @@ def main():
     app.add_typer(chaos, no_args_is_help=True)
 
     @app.callback()
-    def logging_config(loglevel: str = None, log_to_file: Path = None):
+    def logging_config(
+        loglevel: str = None,
+        log_to_file: Path = None,
+        yes: bool = typer.Option(False, "--yes", "-y", help="Skip all confirmation prompts."),
+    ):
+        if yes:
+            enable_yes_flag()
+
         if loglevel:
             valid_loglevels = {
                 "CRITICAL",

--- a/jhack/main.py
+++ b/jhack/main.py
@@ -33,7 +33,7 @@ def main():
     from jhack.charm.update import update
     from jhack.charm.vinfo import vinfo
     from jhack.conf.conf import (
-        enable_yes_flag,
+        enable_devmode_flag,
         print_current_config,
         print_defaults,
         print_destructive,
@@ -83,12 +83,12 @@ def main():
         typer.Typer._extra_args = sys.argv[sep + 1 :]
         sys.argv = sys.argv[:sep]
 
-    # Strip -y/--yes from anywhere in argv before Typer parses them,
+    # Strip --devmode from anywhere in argv before Typer parses them,
     # so the flag works regardless of position in the command.
     remaining = [sys.argv[0]]
     for arg in sys.argv[1:]:
-        if arg in ("-y", "--yes"):
-            enable_yes_flag()
+        if arg == "--devmode":
+            enable_devmode_flag()
         else:
             remaining.append(arg)
     sys.argv = remaining
@@ -277,10 +277,10 @@ def main():
     def logging_config(
         loglevel: str = None,
         log_to_file: Path = None,
-        yes: bool = typer.Option(False, "--yes", "-y", help="Skip all confirmation prompts."),
+        devmode: bool = typer.Option(False, "--devmode", help="Skip all confirmation prompts."),
     ):
-        if yes:
-            enable_yes_flag()
+        if devmode:
+            enable_devmode_flag()
 
         if loglevel:
             valid_loglevels = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jhack"
-version = "0.4.4.0.28"
+version = "0.4.4.0.29"
 requires-python = ">=3.10" # core24 supports up to 3.12 but data platform depends on 3.10
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }


### PR DESCRIPTION
Adds a `--devmode` flag that can be specified to run destructive commands without having to manually enter `y` when prompted or setting `devmode`.


## Before
```
jhack fire prom/0 update-status                                                                                                                                              1 ↵
prom/0 update-status
firing update-status on:
	prom/0
WARNING:jhack./snap/jhack/x1/lib/python3.12/site-packages/jhack/conf/conf.py:
 ** Jhack is now 'safe'! **
All dangerous commands require manual confirmation.

If you know better, you can tune `~/.config/jhack/config.toml` to your needs.

See https://github.com/canonical/jhack?tab=readme-ov-file#enabling-devmode for more.
'fire' would run: 
	 juju ssh prom/0 /usr/bin/juju-exec -u prom/0 JUJU_DISPATCH_PATH=hooks/update-status JUJU_MODEL_NAME=test JUJU_UNIT_NAME=prom/0 /var/lib/juju/agents/unit-prom-0/charm/dispatch
confirm [y/N]: y

```

## After
```
jhack fire prom/0 update-status --devmode
prom/0 update-status
firing update-status on:
	prom/0

```