### PR TITLE
fix(fire): Specify a model respects behavior

### DIFF
--- a/jhack/utils/simulate_event.py
+++ b/jhack/utils/simulate_event.py
@@ -99,10 +99,10 @@ def build_event_env(
     glue: str = " ",
     check_name: str = None,
 ):
-    current_model = get_current_model()
+    model = model or get_current_model()
     env = {
         "JUJU_DISPATCH_PATH": f"hooks/{event}",
-        "JUJU_MODEL_NAME": current_model,
+        "JUJU_MODEL_NAME": model,
         "JUJU_UNIT_NAME": unit,
     }
 
@@ -341,6 +341,7 @@ def _build_command(
         relation_remote=relation_remote,
         notice_id=notice_id,
         relation_id=relation_id,
+        model=model,
         secret_id_or_label=secret_id_or_label,
         override=env_override,
         operator_dispatch=operator_dispatch,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jhack"
-version = "0.4.4.0.29"
+version = "0.4.4.0.30"
 requires-python = ">=3.10" # core24 supports up to 3.12 but data platform depends on 3.10
 authors = [
     { name = "Pietro Pasotti", email = "pietro.pasotti@canonical.com" }


### PR DESCRIPTION
Fixes: #248 

Patches:
 * Use the model when calling `build_event_env`
 * In `build_event_env`, use the model to build the `JUJU_MODEL_NAME`, and fallback to the current model if it exists.